### PR TITLE
Update Comments UI and add support to post a comment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,4 @@
-FROM adoptopenjdk/openjdk14-openj9 AS builder
-COPY ../ .
-RUN ./gradlew backend:installBootDist -Dorg.gradle.daemon=false
-
-FROM adoptopenjdk/openjdk14-openj9
-WORKDIR /usr/app
-COPY --from=builder backend/build/install/backend-boot .
-ENTRYPOINT ["/usr/app/bin/backend"]
+FROM openjdk:8-jdk-alpine
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/ToilappSystemProperties.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/ToilappSystemProperties.kt
@@ -1,0 +1,7 @@
+package com.github.quillraven.toilapp
+
+object ToilappSystemProperties {
+    fun isDevMode(): Boolean {
+        return java.lang.Boolean.getBoolean("toilapp.devmode");
+    }
+}

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/ToilappSystemProperties.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/ToilappSystemProperties.kt
@@ -1,7 +1,5 @@
 package com.github.quillraven.toilapp
 
 object ToilappSystemProperties {
-    fun isDevMode(): Boolean {
-        return java.lang.Boolean.getBoolean("toilapp.devmode");
-    }
+    fun isDevMode() = "true" == System.getProperty("toilapp.devmode")
 }

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/controller/CommentController.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/controller/CommentController.kt
@@ -1,5 +1,6 @@
 package com.github.quillraven.toilapp.controller
 
+import com.github.quillraven.toilapp.model.dto.CreateUpdateCommentDto
 import com.github.quillraven.toilapp.service.CommentService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -7,8 +8,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -18,13 +19,12 @@ class CommentController(
 ) {
     @PostMapping("/comments")
     fun createComment(
-        @RequestParam toiletId: String,
-        @RequestParam userId: String,
-        @RequestParam text: String
-    ) = commentService.createAndLink(userId, text, toiletId)
+        @RequestBody createUpdateCommentDto: CreateUpdateCommentDto
+    ) = commentService.createAndLink(createUpdateCommentDto)
 
-    @PutMapping("/comments/{id}")
-    fun updateComment(@PathVariable id: String, @RequestParam text: String) = commentService.update(id, text)
+    @PutMapping("/comments")
+    fun updateComment(@RequestBody createUpdateCommentDto: CreateUpdateCommentDto) =
+        commentService.update(createUpdateCommentDto)
 
     @GetMapping("/comments/{toiletId}")
     fun getComments(@PathVariable toiletId: String) = commentService.getComments(toiletId)

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/controller/PreviewImageController.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/controller/PreviewImageController.kt
@@ -1,6 +1,7 @@
 package com.github.quillraven.toilapp.controller
 
 import com.github.quillraven.toilapp.service.ImageService
+import com.github.quillraven.toilapp.service.ToiletService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.http.codec.multipart.FilePart
@@ -18,7 +19,8 @@ import reactor.core.publisher.Mono
 @RestController
 @RequestMapping("/api")
 class PreviewImageController(
-    @Autowired private val imageService: ImageService
+    @Autowired private val imageService: ImageService,
+    @Autowired private val toiletService: ToiletService
 ) {
     /*
       FIXME: Transactional is currently not supported by GridFS and therefore we could potentially
@@ -29,7 +31,7 @@ class PreviewImageController(
     fun createPreviewImage(
         @RequestPart("file") file: Mono<FilePart>,
         @RequestParam("toiletId") toiletId: String
-    ) = imageService.createAndLinkImage(file, toiletId)
+    ) = toiletService.createAndLinkImage(file, toiletId)
 
     @GetMapping(
         value = ["/previews/{id}"],

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/model/dto/CreateUpdateCommentDto.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/model/dto/CreateUpdateCommentDto.kt
@@ -1,0 +1,7 @@
+package com.github.quillraven.toilapp.model.dto
+
+data class CreateUpdateCommentDto(
+    val commentId: String = "",
+    val toiletId: String = "",
+    val text: String = ""
+)

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/CommentService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/CommentService.kt
@@ -121,6 +121,7 @@ class DefaultCommentService(
             // and add user name information to each comment
             .flatMap { Mono.just(it).zipWith(userService.getById(it.userRef.toHexString())) }
             .map { createCommentDto(it.t1, it.t2) }
+            .sort { o1, o2 -> o2.date.compareTo(o1.date) }
     }
 
     companion object {

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/CommentService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/CommentService.kt
@@ -93,7 +93,7 @@ class DefaultCommentService(
     }
 
     override fun createAndLink(createUpdateCommentDto: CreateUpdateCommentDto): Mono<CommentDto> {
-        val userId = userService.getCurrentUser()
+        val userId = userService.getCurrentUserId()
         LOG.debug("createAndLink: (userId=$userId, text=${createUpdateCommentDto.text}, toiletId=${createUpdateCommentDto.toiletId})")
         return userService
             // check if user is valid

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/CommentService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/CommentService.kt
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import java.net.URLDecoder
 import java.util.*
 
 interface CommentService {
@@ -90,10 +89,9 @@ class DefaultCommentService(
             // check if user is valid
             .getById(userId)
             // if yes -> create new comment
-            .flatMap { Mono.fromCallable { URLDecoder.decode(text, "UTF-8") } }
             .flatMap {
-                LOG.debug("Found user '$userId' for comment '$it'")
-                create(userId, it)
+                LOG.debug("Found user '$userId' for comment '$text'")
+                create(userId, text)
             }
             // if it was created successfully -> link it to toilet
             .zipWith(toiletService.getById(toiletId))

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/CommentService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/CommentService.kt
@@ -4,6 +4,7 @@ import com.github.quillraven.toilapp.CommentDoesNotExistException
 import com.github.quillraven.toilapp.model.db.Comment
 import com.github.quillraven.toilapp.model.db.User
 import com.github.quillraven.toilapp.model.dto.CommentDto
+import com.github.quillraven.toilapp.model.dto.CreateUpdateCommentDto
 import com.github.quillraven.toilapp.model.dto.UserDto
 import com.github.quillraven.toilapp.repository.CommentRepository
 import org.bson.types.ObjectId
@@ -15,12 +16,12 @@ import reactor.core.publisher.Mono
 import java.util.*
 
 interface CommentService {
-    fun create(userId: String, text: String): Mono<CommentDto>
-    fun update(id: String, text: String): Mono<CommentDto>
+    fun create(userId: ObjectId, text: String): Mono<CommentDto>
+    fun update(createUpdateCommentDto: CreateUpdateCommentDto): Mono<CommentDto>
     fun getById(id: String): Mono<Comment>
     fun deleteAndRemove(id: String): Mono<Void>
     fun delete(id: String): Mono<Void>
-    fun createAndLink(userId: String, text: String, toiletId: String): Mono<CommentDto>
+    fun createAndLink(createUpdateCommentDto: CreateUpdateCommentDto): Mono<CommentDto>
     fun getComments(toiletId: String): Flux<CommentDto>
 }
 
@@ -46,17 +47,25 @@ class DefaultCommentService(
         comment.text
     )
 
-    override fun create(userId: String, text: String): Mono<CommentDto> {
+    override fun create(userId: ObjectId, text: String): Mono<CommentDto> {
         LOG.debug("create: (userId=$userId, text=$text)")
         return commentRepository
-            .save(Comment(userRef = ObjectId(userId), text = text))
+            .save(Comment(userRef = userId, text = text))
             .map { createCommentDto(it) }
     }
 
-    override fun update(id: String, text: String): Mono<CommentDto> {
-        LOG.debug("update: (commentId=$id, text=$text)")
-        return getById(id)
-            .flatMap { commentRepository.save(it.copy(id = ObjectId(id), text = text, date = Date())) }
+    override fun update(createUpdateCommentDto: CreateUpdateCommentDto): Mono<CommentDto> {
+        LOG.debug("update: (commentId=${createUpdateCommentDto.commentId}, text=${createUpdateCommentDto.text})")
+        return getById(createUpdateCommentDto.commentId)
+            .flatMap {
+                commentRepository.save(
+                    it.copy(
+                        id = ObjectId(createUpdateCommentDto.commentId),
+                        text = createUpdateCommentDto.text,
+                        date = Date()
+                    )
+                )
+            }
             .map { createCommentDto(it) }
     }
 
@@ -83,18 +92,19 @@ class DefaultCommentService(
             .flatMap { commentRepository.deleteById(ObjectId(id)) }
     }
 
-    override fun createAndLink(userId: String, text: String, toiletId: String): Mono<CommentDto> {
-        LOG.debug("createAndLink: (userId=$userId, text=$text, toiletId=$toiletId)")
+    override fun createAndLink(createUpdateCommentDto: CreateUpdateCommentDto): Mono<CommentDto> {
+        val userId = userService.getCurrentUser()
+        LOG.debug("createAndLink: (userId=$userId, text=${createUpdateCommentDto.text}, toiletId=${createUpdateCommentDto.toiletId})")
         return userService
             // check if user is valid
             .getById(userId)
             // if yes -> create new comment
             .flatMap {
-                LOG.debug("Found user '$userId' for comment '$text'")
-                create(userId, text)
+                LOG.debug("Found user '$userId' for comment '${createUpdateCommentDto.text}'")
+                create(userId, createUpdateCommentDto.text)
             }
             // if it was created successfully -> link it to toilet
-            .zipWith(toiletService.getById(toiletId))
+            .zipWith(toiletService.getById(createUpdateCommentDto.toiletId))
             .flatMap { tuple ->
                 val comment = tuple.t1
                 val toilet = tuple.t2

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/GridFsImageService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/GridFsImageService.kt
@@ -24,8 +24,6 @@ class GrisFsImageService(
     @Qualifier("reactiveGridFsTemplateForImages")
     @Autowired private val gridFsTemplate: ReactiveGridFsTemplate
 ) : ImageService {
-    lateinit var toiletService: ToiletService
-        @Autowired set
 
     override fun create(filePartMono: Mono<FilePart>): Mono<String> {
         return filePartMono
@@ -89,18 +87,6 @@ class GrisFsImageService(
             DefaultDataBufferFactory.DEFAULT_INITIAL_CAPACITY
         )
         return gridFsTemplate.store(flux, "myName")
-    }
-
-    override fun createAndLinkImage(file: Mono<FilePart>, toiletId: String): Mono<ToiletDto> {
-        LOG.debug("createAndLinkImage: (toiletId=$toiletId)")
-        return toiletService
-            .getById(toiletId)
-            .zipWith(create(file))
-            .flatMap {
-                val toilet = it.t1
-                val fileId = it.t2
-                toiletService.update(toiletId, toilet.copy(previewID = ObjectId(fileId)))
-            }
     }
 
     companion object {

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/GridFsImageService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/GridFsImageService.kt
@@ -2,7 +2,6 @@ package com.github.quillraven.toilapp.service
 
 import com.github.quillraven.toilapp.PreviewImageDoesNotExistException
 import com.github.quillraven.toilapp.UnsupportedImageContentTypeException
-import com.github.quillraven.toilapp.model.dto.ToiletDto
 import org.bson.types.ObjectId
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -20,7 +19,7 @@ import java.io.InputStream
 import java.util.concurrent.Callable
 
 @Service
-class GrisFsImageService(
+class GridFsImageService(
     @Qualifier("reactiveGridFsTemplateForImages")
     @Autowired private val gridFsTemplate: ReactiveGridFsTemplate
 ) : ImageService {
@@ -90,6 +89,6 @@ class GrisFsImageService(
     }
 
     companion object {
-        private val LOG = LoggerFactory.getLogger(GrisFsImageService::class.java)
+        private val LOG = LoggerFactory.getLogger(GridFsImageService::class.java)
     }
 }

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/ImageService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/ImageService.kt
@@ -1,6 +1,5 @@
 package com.github.quillraven.toilapp.service
 
-import com.github.quillraven.toilapp.model.dto.ToiletDto
 import org.bson.types.ObjectId
 import org.springframework.http.codec.multipart.FilePart
 import reactor.core.publisher.Mono

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/ImageService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/ImageService.kt
@@ -11,6 +11,5 @@ interface ImageService {
     fun create(filePartMono: Mono<FilePart>): Mono<String>
     fun get(id: String): Mono<ByteArray>
     fun store(inStreamCallable: Callable<InputStream>, name: String): Mono<ObjectId>
-    fun createAndLinkImage(file: Mono<FilePart>, toiletId: String): Mono<ToiletDto>
     fun delete(id: String): Mono<Void>
 }

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/ToiletService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/ToiletService.kt
@@ -145,14 +145,14 @@ class DefaultToiletService(
     }
 
     override fun createAndLinkImage(file: Mono<FilePart>, toiletId: String): Mono<ToiletDto> {
-        DefaultToiletService.LOG.debug("createAndLinkImage: (toiletId=$toiletId)")
+        LOG.debug("createAndLinkImage: (toiletId=$toiletId)")
         return getById(toiletId)
-                .zipWith(imageService.create(file))
-                .flatMap {
-                    val toilet = it.t1
-                    val fileId = it.t2
-                    update(toiletId, toilet.copy(previewID = ObjectId(fileId)))
-                }
+            .zipWith(imageService.create(file))
+            .flatMap {
+                val toilet = it.t1
+                val fileId = it.t2
+                update(toiletId, toilet.copy(previewID = ObjectId(fileId)))
+            }
     }
 
     companion object {

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/UserService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/UserService.kt
@@ -1,5 +1,6 @@
 package com.github.quillraven.toilapp.service
 
+import com.github.quillraven.toilapp.ToilappSystemProperties
 import com.github.quillraven.toilapp.UserDoesNotExistException
 import com.github.quillraven.toilapp.model.db.User
 import com.github.quillraven.toilapp.model.dto.UserDto
@@ -7,6 +8,7 @@ import com.github.quillraven.toilapp.repository.UserRepository
 import org.bson.types.ObjectId
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Example
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 
@@ -14,7 +16,7 @@ interface UserService {
     fun create(user: User): Mono<UserDto>
     fun getById(id: String): Mono<User>
     fun getById(objectId: ObjectId): Mono<User>
-    fun getCurrentUser(): ObjectId
+    fun getCurrentUserId(): ObjectId
 }
 
 @Service
@@ -46,12 +48,17 @@ class DefaultUserService(
 
     override fun getById(id: String) = getById(ObjectId(id))
 
-    override fun getCurrentUser(): ObjectId {
-        //TODO return user from request
-        return ObjectId("5f9a860c37934c6ee3f49f6c")
+    override fun getCurrentUserId(): ObjectId {
+        if(ToilappSystemProperties.isDevMode()) {
+            //return dev user created by DataLoaderApplication
+            return ObjectId("000000000000012343456789")
+        } else {
+            //TODO return user from request
+            return ObjectId("000000000000012343456789")
+        }
     }
 
     companion object {
-        private val LOG = LoggerFactory.getLogger(DefaultUserService::class.java)
+        private val LOG = LoggerFactory.getLogger(DefaultUserService::class.java);
     }
 }

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/UserService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/UserService.kt
@@ -8,7 +8,6 @@ import com.github.quillraven.toilapp.repository.UserRepository
 import org.bson.types.ObjectId
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.Example
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 
@@ -49,16 +48,19 @@ class DefaultUserService(
     override fun getById(id: String) = getById(ObjectId(id))
 
     override fun getCurrentUserId(): ObjectId {
-        if(ToilappSystemProperties.isDevMode()) {
-            //return dev user created by DataLoaderApplication
-            return ObjectId("000000000000012343456789")
-        } else {
-            //TODO return user from request
-            return ObjectId("000000000000012343456789")
+        return when {
+            ToilappSystemProperties.isDevMode() -> {
+                //return dev user created by DataLoaderApplication
+                ObjectId("000000000000012343456789")
+            }
+            else -> {
+                //TODO return user from request
+                ObjectId("000000000000012343456789")
+            }
         }
     }
 
     companion object {
-        private val LOG = LoggerFactory.getLogger(DefaultUserService::class.java);
+        private val LOG = LoggerFactory.getLogger(DefaultUserService::class.java)
     }
 }

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp/service/UserService.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp/service/UserService.kt
@@ -13,6 +13,8 @@ import reactor.core.publisher.Mono
 interface UserService {
     fun create(user: User): Mono<UserDto>
     fun getById(id: String): Mono<User>
+    fun getById(objectId: ObjectId): Mono<User>
+    fun getCurrentUser(): ObjectId
 }
 
 @Service
@@ -35,11 +37,18 @@ class DefaultUserService(
             .map { createUserDto(it) }
     }
 
-    override fun getById(id: String): Mono<User> {
-        LOG.debug("getById: (id=$id)")
+    override fun getById(objectId: ObjectId): Mono<User> {
+        LOG.debug("getById: (id=$objectId)")
         return userRepository
-            .findById(ObjectId(id))
-            .switchIfEmpty(Mono.error(UserDoesNotExistException(id)))
+            .findById(objectId)
+            .switchIfEmpty(Mono.error(UserDoesNotExistException(objectId.toHexString())))
+    }
+
+    override fun getById(id: String) = getById(ObjectId(id))
+
+    override fun getCurrentUser(): ObjectId {
+        //TODO return user from request
+        return ObjectId("5f9a860c37934c6ee3f49f6c")
     }
 
     companion object {

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp_dataloader/DataLoaderApplication.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp_dataloader/DataLoaderApplication.kt
@@ -105,6 +105,8 @@ class DataLoaderRunner(
     private fun createUsers(): Mono<List<UserDto>> {
         val userMonoList = mutableListOf<Mono<UserDto>>()
         //create users
+        val devUser = User(ObjectId("000000000000012343456789"), "devuser", "devuser@mail.com")
+        userMonoList.add(userService.create(devUser))
         for (usrName in userNames) {
             val userName = userNames[Random.nextInt(0, userNames.size)]
             val email = "$userName@mail.com"

--- a/backend/src/main/kotlin/com/github/quillraven/toilapp_dataloader/DataLoaderApplication.kt
+++ b/backend/src/main/kotlin/com/github/quillraven/toilapp_dataloader/DataLoaderApplication.kt
@@ -118,7 +118,7 @@ class DataLoaderRunner(
         val commentMonoList = mutableListOf<Mono<CommentDto>>()
         for (i in 0..5) {
             val user = users.random()
-            commentMonoList.add(commentService.create(user.id, commentTexts.random()))
+            commentMonoList.add(commentService.create(ObjectId(user.id), commentTexts.random()))
         }
         return Flux.fromIterable(commentMonoList).flatMap { it }.collectList()
     }
@@ -158,7 +158,8 @@ class DataLoaderRunner(
                 disabled = false,
                 toiletCrewApproved = false,
                 description = description,
-                commentRefs = comments.subList(Random.nextInt(4), comments.size).map { ObjectId(it.id) }.toMutableList(),
+                commentRefs = comments.subList(Random.nextInt(4), comments.size).map { ObjectId(it.id) }
+                    .toMutableList(),
                 imageRefs = mutableListOf()
             )
             toiletService.create(toilet)

--- a/backend/src/test/kotlin/com/github/quillraven/toilapp/controller/ToiletControllerSpec.kt
+++ b/backend/src/test/kotlin/com/github/quillraven/toilapp/controller/ToiletControllerSpec.kt
@@ -5,8 +5,11 @@ import com.github.quillraven.toilapp.model.ModelWithFields
 import com.github.quillraven.toilapp.model.ModelWithNoFields
 import com.github.quillraven.toilapp.model.db.Toilet
 import com.github.quillraven.toilapp.model.dto.ToiletDto
+import com.github.quillraven.toilapp.repository.CommentRepository
 import com.github.quillraven.toilapp.repository.ToiletRepository
+import com.github.quillraven.toilapp.service.DefaultCommentService
 import com.github.quillraven.toilapp.service.DefaultToiletService
+import com.github.quillraven.toilapp.service.GridFsImageService
 import io.mockk.every
 import io.mockk.mockk
 import org.amshove.kluent.`should be equal to`
@@ -15,6 +18,7 @@ import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.data.mongodb.core.geo.GeoJsonModule
+import org.springframework.data.mongodb.gridfs.ReactiveGridFsTemplate
 import org.springframework.http.MediaType
 import org.springframework.http.codec.json.Jackson2JsonDecoder
 import org.springframework.http.codec.json.Jackson2JsonEncoder
@@ -26,7 +30,17 @@ import reactor.test.StepVerifier
 @WebFluxTest(controllers = [ToiletController::class])
 object ToiletControllerSpec : Spek({
     val toiletRepository: ToiletRepository by memoized { mockk<ToiletRepository>() }
-    val toiletService: DefaultToiletService by memoized { DefaultToiletService(toiletRepository) }
+    val commentRepository: CommentRepository by memoized { mockk<CommentRepository>() }
+    val gridFsTemplate: ReactiveGridFsTemplate by memoized { mockk<ReactiveGridFsTemplate>() }
+    val commentService: DefaultCommentService by memoized { DefaultCommentService(commentRepository) }
+    val imageService: GridFsImageService by memoized { GridFsImageService(gridFsTemplate) }
+    val toiletService: DefaultToiletService by memoized {
+        DefaultToiletService(
+            toiletRepository,
+            commentService,
+            imageService
+        )
+    }
     val client by memoized {
         WebTestClient
             .bindToController(ToiletController(toiletService))

--- a/backend/src/test/kotlin/com/github/quillraven/toilapp/service/ToiletServiceSpec.kt
+++ b/backend/src/test/kotlin/com/github/quillraven/toilapp/service/ToiletServiceSpec.kt
@@ -2,19 +2,31 @@ package com.github.quillraven.toilapp.service
 
 import com.github.quillraven.toilapp.ToiletDoesNotExistException
 import com.github.quillraven.toilapp.model.db.Toilet
+import com.github.quillraven.toilapp.repository.CommentRepository
 import com.github.quillraven.toilapp.repository.ToiletRepository
 import io.mockk.every
 import io.mockk.mockk
 import org.bson.types.ObjectId
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import org.springframework.data.mongodb.gridfs.ReactiveGridFsTemplate
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 
 object ToiletServiceSpec : Spek({
     val toiletRepository: ToiletRepository by memoized { mockk<ToiletRepository>() }
-    val toiletService: DefaultToiletService by memoized { DefaultToiletService(toiletRepository) }
+    val commentRepository: CommentRepository by memoized { mockk<CommentRepository>() }
+    val gridFsTemplate: ReactiveGridFsTemplate by memoized { mockk<ReactiveGridFsTemplate>() }
+    val commentService: DefaultCommentService by memoized { DefaultCommentService(commentRepository) }
+    val imageService: GridFsImageService by memoized { GridFsImageService(gridFsTemplate) }
+    val toiletService: DefaultToiletService by memoized {
+        DefaultToiletService(
+            toiletRepository,
+            commentService,
+            imageService
+        )
+    }
 
     describe("A Toilet service") {
         it("should create a new toilet") {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1683,6 +1683,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "4.11.0",
     "@material-ui/icons": "4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@testing-library/jest-dom": "5.11.5",
     "@testing-library/react": "11.1.0",
     "@testing-library/user-event": "12.1.10",

--- a/frontend/src/components/Comments.tsx
+++ b/frontend/src/components/Comments.tsx
@@ -31,6 +31,9 @@ const useStyles = makeStyles((theme: Theme) =>
         commentGridList: {
             height: 200,
         },
+        commentDiv: {
+            whiteSpace: "pre-wrap"
+        }
     }),
 );
 
@@ -51,7 +54,7 @@ export default function Comments(props: CommentsProps) {
     const postComment = () => {
         // TODO retrieve correct user id
         toiletService
-            .postComment(props.toilet.id, "5f8c0cec25209253b4a2e31e", newCommentText)
+            .postComment(props.toilet.id, "5f9a860c37934c6ee3f49f6c", newCommentText)
             .then(() => {
                 console.log("Comment posted")
                 setNewCommentText("")
@@ -104,7 +107,7 @@ export default function Comments(props: CommentsProps) {
                 <GridList cellHeight="auto" className={classes.commentGridList} cols={1}>
                     {
                         comments.map((comment, idx) => (
-                            <div key={`Comment-${props.toilet.id}-${idx}`}>
+                            <div className={classes.commentDiv} key={`Comment-${props.toilet.id}-${idx}`}>
                                 <GridListTile>
                                     <Typography color="textSecondary">
                                         {comment.date.toLocaleTimeString(navigator.language, {

--- a/frontend/src/components/Comments.tsx
+++ b/frontend/src/components/Comments.tsx
@@ -3,26 +3,33 @@ import React, {useEffect, useState} from "react";
 import {Toilet} from "../model/Toilet";
 import {ToiletComment} from "../model/ToiletComment"
 import {RestToiletService, ToiletService} from "../services/ToiletService";
-import {
-    Accordion,
-    AccordionDetails,
-    AccordionSummary,
-    List,
-    ListItem,
-    ListItemText,
-    Typography
-} from "@material-ui/core";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import TextField from "@material-ui/core/TextField"
+import {Divider, GridList, GridListTile, IconButton, Typography} from "@material-ui/core";
+import {Send} from "@material-ui/icons";
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
-        root: {
-            width: '100%',
-            maxWidth: '36ch',
+        header: {
+            h4: {
+                display: "inline-block",
+            }
+        },
+        addCommentForm: {
+            '& > *': {
+                marginLeft: theme.spacing(1),
+                width: '25ch',
+                display: "flex",
+            },
+        },
+        commentGridListDiv: {
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "space-around",
+            overflow: "hidden",
             backgroundColor: theme.palette.background.paper,
         },
-        inline: {
-            display: 'inline',
+        commentGridList: {
+            height: 200,
         },
     }),
 );
@@ -34,59 +41,93 @@ interface CommentsProps {
 export default function Comments(props: CommentsProps) {
     const classes = useStyles();
     const [comments, setComments] = useState<ToiletComment[]>([]);
+    const [newCommentText, setNewCommentText] = useState<string>("")
     const toiletService: ToiletService = new RestToiletService();
+
+    const updateComment = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setNewCommentText(e.currentTarget.value)
+    }
+
+    const postComment = () => {
+        // TODO retrieve correct user id
+        toiletService
+            .postComment(props.toilet.id, "5f8c0cec25209253b4a2e31e", newCommentText)
+            .then(() => {
+                console.log("Comment posted")
+                setNewCommentText("")
+                return toiletService.getComments(props.toilet)
+            })
+            .then(comments => {
+                console.log(`New comments: ${comments.length}`)
+                setComments(comments)
+            })
+    };
 
     useEffect(() => {
         toiletService
             .getComments(props.toilet)
             .then(comments => {
-                console.log("Comments loaded")
+                console.log(`${comments.length} comments loaded`)
                 setComments(comments)
             })
         // eslint-disable-next-line
     }, []);
 
     return (
-        <Accordion>
-            <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
-                <div>
-                    <Typography>
-                        View Comments
-                    </Typography>
-                </div>
-            </AccordionSummary>
-            <AccordionDetails>
-                <List className={classes.root}>
+        <React.Fragment>
+            <div className={classes.header}>
+                <h4>{comments.length} Comments</h4>
+                <form className={classes.addCommentForm} noValidate autoComplete="off">
+                    <TextField
+                        id={"Comments-for-" + props.toilet.id}
+                        placeholder="Add Comment"
+                        value={newCommentText}
+                        multiline
+                        onChange={updateComment}
+                        InputProps={{
+                            endAdornment: (
+                                <IconButton
+                                    aria-label="send"
+                                    onClick={postComment}
+                                    disabled={!newCommentText}
+                                    color="primary"
+                                >
+                                    <Send/>
+                                </IconButton>
+                            )
+                        }}
+                    />
+                    <br/>
+                </form>
+            </div>
+            <div>
+                <GridList cellHeight="auto" className={classes.commentGridList} cols={1}>
                     {
                         comments.map((comment, idx) => (
-                            <ListItem alignItems="flex-start" key={`Comment-${idx}`}>
-                                <ListItemText
-                                    primary={comment.user.name}
-                                    secondary={
-                                        <React.Fragment>
-                                            <Typography
-                                                component="span"
-                                                variant="body1"
-                                                className={classes.inline}
-                                                color="textPrimary"
-                                            >
-                                                {comment.date.toLocaleString()}
-                                            </Typography>
-                                            <br/>
-                                            <Typography
-                                                component="span"
-                                                variant="body2"
-                                            >
-                                                {comment.text}
-                                            </Typography>
-                                        </React.Fragment>
-                                    }
-                                />
-                            </ListItem>
+                            <div key={`Comment-${props.toilet.id}-${idx}`}>
+                                <GridListTile>
+                                    <Typography color="textSecondary">
+                                        {comment.date.toLocaleTimeString(navigator.language, {
+                                            year: "numeric",
+                                            month: "numeric",
+                                            day: "numeric",
+                                            hour: "2-digit",
+                                            minute: "2-digit"
+                                        })}
+                                    </Typography>
+                                    <Typography variant="h5" component="h2" gutterBottom>
+                                        {comment.user.name}
+                                    </Typography>
+                                    <Typography variant="body2" component="p">
+                                        {comment.text}
+                                    </Typography>
+                                </GridListTile>
+                                {idx !== comments.length - 1 && <Divider/>}
+                            </div>
                         ))
                     }
-                </List>
-            </AccordionDetails>
-        </Accordion>
+                </GridList>
+            </div>
+        </React.Fragment>
     );
 }

--- a/frontend/src/components/Comments.tsx
+++ b/frontend/src/components/Comments.tsx
@@ -60,9 +60,8 @@ export default function Comments(props: CommentsProps) {
     }
 
     const postComment = () => {
-        // TODO retrieve correct user id
         toiletService
-            .postComment(props.toilet.id, "5f9a860c37934c6ee3f49f6c", newCommentText)
+            .postComment(props.toilet.id, newCommentText)
             .then(response => {
                 if (response) {
                     console.log("Comment posted")

--- a/frontend/src/components/ToiletDetailsItem.tsx
+++ b/frontend/src/components/ToiletDetailsItem.tsx
@@ -1,4 +1,4 @@
-import {Grid, Typography} from "@material-ui/core";
+import {Divider, Grid, Typography} from "@material-ui/core";
 import React from "react";
 import {RatingView} from "./Rating";
 import {Toilet} from "../model/Toilet";
@@ -39,11 +39,11 @@ export default function ToiletDetailsItem(props: ToiletDetailsItemProps) {
                     <Typography>
                         {toilet.description}
                     </Typography>
+                    <br/>
+                    <Divider variant="middle"/>
+                    <Comments toilet={toilet}/>
                 </Grid>
             </Grid>
-            <div>
-                <Comments toilet={toilet}/>
-            </div>
         </React.Fragment>
     )
 }

--- a/frontend/src/model/ToiletComment.tsx
+++ b/frontend/src/model/ToiletComment.tsx
@@ -6,3 +6,9 @@ export interface ToiletComment {
     date: Date,
     text: string,
 }
+
+export interface CreateUpdateComment {
+    commentId: string,
+    toiletId: string,
+    text: string,
+}

--- a/frontend/src/services/ToiletService.ts
+++ b/frontend/src/services/ToiletService.ts
@@ -47,8 +47,11 @@ export class RestToiletService implements ToiletService {
     }
 
     public postComment(toiletId: string, userId: string, text: string): Promise<ToiletComment> {
+        const encodedText = encodeURIComponent(text)
+        console.log(`Posting '${encodedText}'`)
+
         return axios
-            .post(API_ENDPOINT + `/comments/?toiletId=${toiletId}&userId=${userId}&text=${encodeURI(text)}`)
+            .post(API_ENDPOINT + `/comments/?toiletId=${toiletId}&userId=${userId}&text=${encodedText}`)
             .then(response => {
                 const comment: ToiletComment = response.data
 

--- a/frontend/src/services/ToiletService.ts
+++ b/frontend/src/services/ToiletService.ts
@@ -8,6 +8,8 @@ export interface ToiletService {
     getToilets(geoLocation: GeoLocation): Promise<Toilet[]>
 
     getComments(toilet: Toilet): Promise<ToiletComment[]>
+
+    postComment(toiletId: string, userId: string, text: string): Promise<ToiletComment>
 }
 
 export class RestToiletService implements ToiletService {
@@ -41,6 +43,22 @@ export class RestToiletService implements ToiletService {
                 return response.data
             }, error => {
                 console.error(`Could not get comments for toilet '${toilet.id}'. Error=${error}`)
+            })
+    }
+
+    public postComment(toiletId: string, userId: string, text: string): Promise<ToiletComment> {
+        return axios
+            .post(API_ENDPOINT + `/comments/?toiletId=${toiletId}&userId=${userId}&text=${encodeURI(text)}`)
+            .then(response => {
+                const comment: ToiletComment = response.data
+
+                // TODO is there a way to retrieve already a correct date instance from REST directly?
+                //  we currently receive a string
+                comment.date = new Date(comment.date)
+
+                return response.data
+            }, error => {
+                console.error(`Could not post comment for toilet '${toiletId}'. Error=${error}`)
             })
     }
 }
@@ -110,6 +128,22 @@ export class MockToiletService implements ToiletService {
         return new Promise<ToiletComment[]>(function (resolve) {
             const comments: ToiletComment[] = []
             resolve(comments)
+        })
+    }
+
+    postComment(toiletId: string, userId: string, text: string): Promise<ToiletComment> {
+        return new Promise<ToiletComment>(function (resolve) {
+            const comment: ToiletComment = {
+                id: "",
+                user: {
+                    name: "",
+                    email: "",
+                    id: ""
+                },
+                date: new Date(),
+                text: ""
+            }
+            resolve(comment)
         })
     }
 }

--- a/frontend/src/services/ToiletService.ts
+++ b/frontend/src/services/ToiletService.ts
@@ -2,14 +2,14 @@ import {API_ENDPOINT} from "./ServiceConstants";
 import axios from "axios";
 import {Toilet} from "../model/Toilet";
 import {GeoLocation} from "../model/GeoLocation";
-import {ToiletComment} from "../model/ToiletComment";
+import {CreateUpdateComment, ToiletComment} from "../model/ToiletComment";
 
 export interface ToiletService {
     getToilets(geoLocation: GeoLocation): Promise<Toilet[]>
 
     getComments(toilet: Toilet): Promise<ToiletComment[]>
 
-    postComment(toiletId: string, userId: string, text: string): Promise<ToiletComment>
+    postComment(toiletId: string, text: string): Promise<ToiletComment>
 }
 
 export class RestToiletService implements ToiletService {
@@ -46,12 +46,18 @@ export class RestToiletService implements ToiletService {
             })
     }
 
-    public postComment(toiletId: string, userId: string, text: string): Promise<ToiletComment> {
-        const encodedText = encodeURIComponent(text)
-        console.log(`Posting '${encodedText}'`)
+    public postComment(toiletId: string, text: string): Promise<ToiletComment> {
+        console.log(`Posting '${text}'`)
 
         return axios
-            .post(API_ENDPOINT + `/comments/?toiletId=${toiletId}&userId=${userId}&text=${encodedText}`)
+            .post(
+                API_ENDPOINT + `/comments`,
+                {
+                    commentId: "",
+                    toiletId: toiletId,
+                    text: text,
+                } as CreateUpdateComment
+            )
             .then(response => {
                 const comment: ToiletComment = response.data
 
@@ -134,7 +140,7 @@ export class MockToiletService implements ToiletService {
         })
     }
 
-    postComment(toiletId: string, userId: string, text: string): Promise<ToiletComment> {
+    postComment(toiletId: string, text: string): Promise<ToiletComment> {
         return new Promise<ToiletComment>(function (resolve) {
             const comment: ToiletComment = {
                 id: "",


### PR DESCRIPTION
I replaced the `Accordion` with a `GridList` and split the comments now into three areas:

- header: contains the amount of comments. Could later on be enhanced to add a filter functionality
- add new coment: text area to enter a new comment and button to post it. The button is only active when a text is entered. The text area gets cleared when a comment is successfully posted
- comments area: shows all comments sorted by the backend. The latest comment appears at the top.

Header and comments area get automatically updated when a new comment is posted.


How are strings usually handled in such a case because e.g. when I enter a "%" character then it cannot be send to the server. Also, newlines seem to disappear on the frontend. I guess it is because they are stored as "\n" on the server and in html we need "<\br>"?

I assume there are already utility functions for such things available?

----

![image](https://user-images.githubusercontent.com/93260/97165987-ca2cfd00-1784-11eb-8527-63f7a2bcac07.png)

![image](https://user-images.githubusercontent.com/93260/97166027-dd3fcd00-1784-11eb-8770-8ed3596f6538.png)

![image](https://user-images.githubusercontent.com/93260/97166083-f3e62400-1784-11eb-9da2-4e47a879c1a8.png)





