### PR TITLE
Feature/toilet creation form

### DIFF
--- a/frontend/src/components/ToiletDialog.tsx
+++ b/frontend/src/components/ToiletDialog.tsx
@@ -1,0 +1,224 @@
+import React, {Dispatch, forwardRef, SetStateAction, useImperativeHandle, useState} from "react";
+import {
+    Box,
+    Button,
+    Checkbox,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    IconButton,
+    TextField
+} from "@material-ui/core";
+import {createStyles, makeStyles, Theme} from "@material-ui/core/styles";
+import {PhotoCamera} from "@material-ui/icons";
+import {GeoLocation} from "../model/GeoLocation";
+import {ToiletServiceProvider} from "../services/ToiletService";
+
+const useStyles = makeStyles((_: Theme) =>
+    createStyles({
+        inputImage: {
+            display: "none",
+        },
+    }),
+);
+
+export interface ToiletDialogRef {
+    handleOpen(): void
+}
+
+interface ToiletDialogProps {
+    title: string,
+    dispatchAlert: Dispatch<SetStateAction<boolean>>,
+}
+
+const EMPTY_LOCATION = 9999
+
+export const ToiletDialog = forwardRef<ToiletDialogRef, ToiletDialogProps>((props, ref) => {
+    const classes = useStyles()
+    const toiletService = ToiletServiceProvider.getToiletService()
+    const [open, setOpen] = useState(false)
+    const [title, setTitle] = useState("")
+    const [description, setDescription] = useState("")
+    const [thumbnail, setThumbnail] = useState<File | null>(null)
+    const [disabled, setDisabled] = useState(false)
+    // TODO prefill location with current location from user
+    const [location, setLocation] = useState<GeoLocation>({lat: EMPTY_LOCATION, lon: EMPTY_LOCATION} as GeoLocation)
+
+    const updateTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setTitle(e.target.value)
+    }
+
+    const updateDescription = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setDescription(e.target.value)
+    }
+
+    const updateDisabled = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setDisabled(e.target.checked)
+    }
+
+    const updateThumbnail = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files && e.target.files.length > 0) {
+            setThumbnail(e.target.files[0])
+        } else {
+            setThumbnail(null)
+        }
+    }
+
+    const updateLongitude = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.value.length > 0) {
+            setLocation(prevLocation => {
+                return {...prevLocation, lon: e.target.valueAsNumber}
+            })
+        } else {
+            setLocation(prevLocation => {
+                return {...prevLocation, lon: EMPTY_LOCATION}
+            })
+        }
+    }
+
+    const updateLatitude = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.value.length > 0) {
+            setLocation(prevLocation => {
+                return {...prevLocation, lat: e.target.valueAsNumber}
+            })
+        } else {
+            setLocation(prevLocation => {
+                return {...prevLocation, lat: EMPTY_LOCATION}
+            })
+        }
+    }
+
+    function validateInput(): boolean {
+        return title.length > 0 && location.lat !== EMPTY_LOCATION && location.lon !== EMPTY_LOCATION
+    }
+
+    const handleSubmit = () => {
+        if (validateInput()) {
+            toiletService
+                .createUpdateToilet(
+                    title,
+                    location,
+                    disabled,
+                    description
+                )
+                .then(response => {
+                        if (response) {
+                            console.log(`Successfully created toilet '${response.id}'`)
+                            if (thumbnail) {
+                                toiletService
+                                    .updatePreviewImage(response.id, thumbnail)
+                                    .then(response => {
+                                        if (response) {
+                                            console.log(`Successfully updated preview`)
+                                        }
+                                    })
+                            }
+                            props.dispatchAlert(true)
+                            handleClose()
+                        }
+                    }
+                )
+        }
+    }
+
+    const handleClose = () => {
+        setTitle("")
+        setDescription("")
+        setThumbnail(null)
+        setLocation({lat: EMPTY_LOCATION, lon: EMPTY_LOCATION})
+        setOpen(false)
+    }
+
+    const handleOpen = () => {
+        setOpen(true)
+    }
+
+    useImperativeHandle(ref, () => ({handleOpen}))
+
+    return (
+        <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+            <DialogTitle id="form-dialog-title">{props.title}</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    Provide the necessary information below and click on <b>OK</b> to submit it. <br/>
+                    Fields marked with a <b>*</b> are mandatory.
+                </DialogContentText>
+                <TextField
+                    required
+                    error={title.length <= 0}
+                    onChange={updateTitle}
+                    autoFocus
+                    margin="dense"
+                    id="toilet-dialog-title"
+                    label="Title"
+                    fullWidth
+                />
+                <TextField
+                    required
+                    onChange={updateLongitude}
+                    error={location.lon === EMPTY_LOCATION}
+                    margin="dense"
+                    id="toilet-dialog-longitude"
+                    label="Longitude"
+                    type="number"
+                />
+                <TextField
+                    required
+                    onChange={updateLatitude}
+                    error={location.lat === EMPTY_LOCATION}
+                    margin="dense"
+                    id="toilet-dialog-latitude"
+                    label="Latitude"
+                    type="number"
+                />
+                <br/>
+                <Box display="flex" alignItems="center">
+                    <TextField
+                        margin="dense"
+                        label="Disabled"
+                        disabled
+                    />
+                    <Checkbox
+                        color="primary"
+                        onChange={updateDisabled}
+                    />
+                </Box>
+                <TextField
+                    margin="dense"
+                    onChange={updateDescription}
+                    id="toilet-dialog-description"
+                    label="Description"
+                    fullWidth
+                />
+                <input accept="image/png,image/jpeg"
+                       className={classes.inputImage}
+                       id="toilet-dialog-image"
+                       type="file"
+                       onChange={updateThumbnail}
+                />
+                <label htmlFor="toilet-dialog-image">
+                    <Box display="flex" alignItems="center">
+                        <TextField
+                            margin="dense"
+                            label={thumbnail ? thumbnail.name.substr(0, 15) : "Thumbnail"}
+                            disabled
+                        />
+                        <IconButton color="primary" aria-label="upload picture" component="span">
+                            <PhotoCamera/>
+                        </IconButton>
+                    </Box>
+                </label>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose} color="primary">
+                    Cancel
+                </Button>
+                <Button onClick={handleSubmit} color="primary">
+                    OK
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+})

--- a/frontend/src/components/ToiletOverviewItem.tsx
+++ b/frontend/src/components/ToiletOverviewItem.tsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles((_: Theme) =>
             // display and width make the CardActionArea size equal to the grid item size
             display: "flex",
             flex: 1,
+            borderRadius: "20px",
         },
         cardActionArea: {
             display: "flex",

--- a/frontend/src/model/CreateUpdateToilet.ts
+++ b/frontend/src/model/CreateUpdateToilet.ts
@@ -1,10 +1,13 @@
-import {GeoLocation} from "./GeoLocation";
+export interface GeoLocationParam {
+    type: string,
+    coordinates: number[]
+}
 
 export interface CreateUpdateToilet {
     id: string,
     title: string,
     description: string,
-    location: GeoLocation,
+    location: GeoLocationParam,
     disabled: boolean,
     toiletCrewApproved: boolean,
 }

--- a/frontend/src/view/ToiletOverviewView.tsx
+++ b/frontend/src/view/ToiletOverviewView.tsx
@@ -1,12 +1,15 @@
-import React, {useEffect, useState} from 'react';
+import React, {createRef, useEffect, useState} from 'react';
 import {createStyles, makeStyles, Theme} from '@material-ui/core/styles';
 import {GeoLocationService, GeoLocationServiceProvider} from '../services/GeoLocationService';
-import {Container, Grid, Grow} from "@material-ui/core";
+import {Container, Fab, Grid, Grow, Snackbar} from "@material-ui/core";
 import {ToiletOverview} from "../model/ToiletOverview";
 import {ToiletService, ToiletServiceProvider} from "../services/ToiletService";
 import ToiletOverviewItem from "../components/ToiletOverviewItem";
+import {Add} from "@material-ui/icons";
+import {ToiletDialog, ToiletDialogRef} from "../components/ToiletDialog";
+import {Alert} from "@material-ui/lab";
 
-const useStyles = makeStyles((_: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         rootContainer: {
             paddingTop: 16,
@@ -15,14 +18,31 @@ const useStyles = makeStyles((_: Theme) =>
         gridItem: {
             display: "flex", // this line makes every grid item of the same height if the container is set to stretch
         },
+        dialogButton: {
+            position: "sticky",
+            bottom: theme.spacing(2),
+            marginRight: theme.spacing(2),
+            left: "100%",
+            ariaLabel: "add",
+        },
     }),
 );
 
 export default function ToiletOverviewView() {
     const classes = useStyles();
-    const [toiletOverviews, setToiletOverviews] = useState<ToiletOverview[]>([]);
     const toiletService: ToiletService = ToiletServiceProvider.getToiletService()
     const locationService: GeoLocationService = GeoLocationServiceProvider.getGeoLocationService()
+    const [toiletOverviews, setToiletOverviews] = useState<ToiletOverview[]>([]);
+    const [showAlert, setShowAlert] = useState(false)
+    const dialogRef = createRef<ToiletDialogRef>()
+
+    const closeAlert = (event?: React.SyntheticEvent, reason?: string) => {
+        if (reason === 'clickaway') {
+            return;
+        }
+
+        setShowAlert(false)
+    }
 
     useEffect(() => {
         toiletService
@@ -60,6 +80,17 @@ export default function ToiletOverviewView() {
                     }
                 </Grid>
             </Grow>
+            <ToiletDialog ref={dialogRef} title="Create new toilet" dispatchAlert={setShowAlert}/>
+            <Fab className={classes.dialogButton} color="primary">
+                <Add onClick={() => {
+                    dialogRef.current?.handleOpen()
+                }}/>
+            </Fab>
+            <Snackbar open={showAlert} autoHideDuration={6000} onClose={closeAlert}>
+                <Alert severity="success" onClose={closeAlert}>
+                    Successfully created toilet
+                </Alert>
+            </Snackbar>
         </Container>
     );
 }


### PR DESCRIPTION
- adds popup dialog to overview to create new toilets
- add sticky button relative to overview container (bottom right corner) that opens the dialog
    ![image](https://user-images.githubusercontent.com/93260/103462547-39474480-4d26-11eb-8c9f-e7e1ff329bc7.png)
- title and location are mandatory
    ![image](https://user-images.githubusercontent.com/93260/103462554-482df700-4d26-11eb-9ea5-e09fec9ae597.png)
- image selection allows only png and jpg format and shows the selected filename
    ![image](https://user-images.githubusercontent.com/93260/103462574-78759580-4d26-11eb-9fa6-0def94b02c91.png)
- "OK" submits the data to the server in two calls. First the toilet is created. Second, the preview image is updated




